### PR TITLE
[ruby]:  Add inspec tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# ruby
+
+A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,15 +1,96 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.ruby?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=280&branchName=master)
+
 # ruby
 
-A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to   read and easy to write.
+A dynamic, open source programming language with a focus on   simplicity and productivity. It has an elegant syntax that is natural to read and easy to write.  See [documentation](https://www.ruby-lang.org/en/)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/ruby as a dependency, you can add one of the following to your plan file.
+
+#### Buildtime Dependency
+
+> pkg_build_deps=(core/ruby)
+
+#### Runtime dependency
+
+> pkg_deps=(core/ruby)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/ruby --binlink``
+
+will add the following binaries to the PATH:
+
+* /bin/bundle
+* /bin/erb
+* /bin/gem
+* /bin/irb
+* /bin/rake
+* /bin/rdoc
+* /bin/ri
+* /bin/ruby
+* /bin/update_rubygems
+
+For example:
+
+```bash
+$ hab pkg install core/ruby --binlink
+» Installing core/ruby
+☁ Determining latest version of core/ruby in the 'stable' channel
+→ Found newer installed version (core/ruby/2.5.8/20200928183217) than remote version (core/ruby/2.5.7/20200404130135)
+→ Using core/ruby/2.5.8/20200928183217
+★ Install of core/ruby/2.5.8/20200928183217 complete with 0 new packages installed.
+» Binlinking irb from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked irb from core/ruby/2.5.8/20200928183217 to /bin/irb
+» Binlinking ruby from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked ruby from core/ruby/2.5.8/20200928183217 to /bin/ruby
+» Binlinking gem from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked gem from core/ruby/2.5.8/20200928183217 to /bin/gem
+» Binlinking update_rubygems from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked update_rubygems from core/ruby/2.5.8/20200928183217 to /bin/update_rubygems
+» Binlinking erb from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked erb from core/ruby/2.5.8/20200928183217 to /bin/erb
+» Binlinking rdoc from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked rdoc from core/ruby/2.5.8/20200928183217 to /bin/rdoc
+» Binlinking rake from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked rake from core/ruby/2.5.8/20200928183217 to /bin/rake
+» Binlinking bundle from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked bundle from core/ruby/2.5.8/20200928183217 to /bin/bundle
+» Binlinking ri from core/ruby/2.5.8/20200928183217 into /bin
+★ Binlinked ri from core/ruby/2.5.8/20200928183217 to /bin/ri
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/ruby --help`` or ``ruby --help``
+
+```bash
+$ ruby --help
+Usage: ruby [switches] [--] [programfile] [arguments]
+  -0[octal]       specify record separator (\0, if no argument)
+  -a              autosplit mode with -n or -p (splits $_ into $F)
+  -c              check syntax only
+  -Cdirectory     cd to directory before executing your script
+  -d, --debug     set debugging flags (set $DEBUG to true)
+  -e 'command'    one line of script. Several -e's allowed. Omit [programfile]
+  -Eex[:in], --encoding=ex[:in]
+...
+...
+```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-plan_name: ''
+plan_name: 'ruby'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines-package-install-next.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,3 +1,4 @@
 ---
 owners:
+  - "@smacfarlane"
   - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/ruby_exists.rb
+++ b/controls/ruby_exists.rb
@@ -1,0 +1,37 @@
+title 'Tests to confirm ruby exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'ruby')
+
+control 'core-plans-ruby-exists' do
+  impact 1.0
+  title 'Ensure ruby exists'
+  desc '
+  Verify ruby by ensuring bin/ruby 
+  (1) exists and
+  (2) is executable'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  [
+    "bundle",
+    "erb",
+    "gem",
+    "irb",
+    "rake",
+    "rdoc",
+    "ri",
+    "ruby",
+    "update_rubygems",
+  ].each do |binary_name|
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe file(command_full_path) do
+      it { should exist }
+      it { should be_executable }
+    end
+  end
+end

--- a/controls/ruby_works.rb
+++ b/controls/ruby_works.rb
@@ -1,0 +1,68 @@
+title 'Tests to confirm ruby works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'ruby')
+
+control 'core-plans-ruby-works' do
+  impact 1.0
+  title 'Ensure ruby works as expected'
+  desc '
+  Verify ruby by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  full_suite = {
+    "bundle" => {
+      command_output_pattern: /Bundler\s+commands:/,
+    },
+    "erb" => {
+      command_output_pattern: /erb\s+\[switches\]/,
+      exit_pattern: /^[^0]/,
+    },
+    "gem" => {
+      command_suffix: "env",
+      command_output_pattern: /RUBY\s+VERSION:\s+#{plan_pkg_version}/,
+    },
+    "irb" => {},
+    # uncomment after fixing issue https://github.com/chef-base-plans/ruby/issues/1
+    # "rake" => {
+    #   command_output_pattern: /rake \[-f rakefile\]/,
+    # },
+    "rdoc" => {},
+    "ri" => {},
+    "ruby" => {
+      command_suffix: "--version",
+      command_output_pattern: /ruby\s+#{plan_pkg_version}/,
+    },
+    # uncomment after fixing issue https://github.com/chef-base-plans/ruby/issues/1
+    # "update_rubygems" => {
+    #   command_output_pattern: /rubygems_update \[options\]/,
+    # },
+  }
+  
+  # Use the following to pull out a subset of the above and test progressiveluy
+  subset = full_suite.select { |key, value| key.to_s.match(/^.*$/) }
+  
+  # over-ride the defaults below with (command_suffix:, io:, etc)
+  subset.each do |binary_name, value|
+    # set default values if each binary doesn't define an over-ride
+    command_suffix = value.has_key?(:command_suffix) ? "#{value[:command_suffix]} 2>&1" : "--help 2>&1"
+    command_output_pattern = value[:command_output_pattern] || /usage:(\s+|.*)#{binary_name}/i
+    exit_pattern = value[:exit_pattern] || /^[0]$/ # use /^[^0]{1}\d*$/ for non-zero exit status
+
+    # verify output
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe bash("#{command_full_path} #{command_suffix}") do
+      its('exit_status') { should cmp exit_pattern }
+      its('stdout') { should match command_output_pattern }
+    end
+  end
+end

--- a/controls/ruby_works.rb
+++ b/controls/ruby_works.rb
@@ -24,6 +24,7 @@ control 'core-plans-ruby-works' do
       command_output_pattern: /Bundler\s+commands:/,
     },
     "erb" => {
+      command_suffix: "--help 2>&1",
       command_output_pattern: /erb\s+\[switches\]/,
       exit_pattern: /^[^0]/,
     },
@@ -54,7 +55,7 @@ control 'core-plans-ruby-works' do
   # over-ride the defaults below with (command_suffix:, io:, etc)
   subset.each do |binary_name, value|
     # set default values if each binary doesn't define an over-ride
-    command_suffix = value.has_key?(:command_suffix) ? "#{value[:command_suffix]} 2>&1" : "--help 2>&1"
+    command_suffix = value.has_key?(:command_suffix) ? "#{value[:command_suffix]}" : "--help"
     command_output_pattern = value[:command_output_pattern] || /usage:(\s+|.*)#{binary_name}/i
     exit_pattern = value[:exit_pattern] || /^[0]$/ # use /^[^0]{1}\d*$/ for non-zero exit status
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: ruby
+title: Habitat Core Plan ruby
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan ruby
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,43 @@
+pkg_name=ruby
+pkg_origin=core
+pkg_version=2.5.8
+pkg_description="A dynamic, open source programming language with a focus on \
+  simplicity and productivity. It has an elegant syntax that is natural to \
+  read and easy to write."
+pkg_license=("Ruby")
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz
+pkg_upstream_url=https://www.ruby-lang.org/en/
+pkg_shasum=6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a
+pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+pkg_interpreters=(bin/ruby)
+
+do_prepare() {
+  export CFLAGS="${CFLAGS} -O3 -g -pipe"
+  build_line "Setting CFLAGS='$CFLAGS'"
+}
+
+do_build() {
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --enable-shared \
+    --disable-install-doc \
+    --with-openssl-dir="$(pkg_path_for core/openssl)" \
+    --with-libyaml-dir="$(pkg_path_for core/libyaml)"
+
+  make
+}
+
+do_check() {
+  make test
+}
+
+do_install() {
+  do_default_install
+  gem update --system 2.7.9 --no-document
+  gem install rb-readline --no-document
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,53 @@
+expected_version="$(echo $TEST_PKG_IDENT | cut -d/ -f3)"
+
+@test "ruby runs" {
+  run hab pkg exec $TEST_PKG_IDENT ruby -v
+  [ $status -eq 0 ]
+}
+
+@test "is expected version ${expected_version}" {
+  actual_version=$(hab pkg exec $TEST_PKG_IDENT ruby -v | grep -o 'ruby .*p')
+  [ "${actual_version}" = "ruby ${expected_version}p" ]
+}
+
+@test "provides a gem command" {
+  run hab pkg exec $TEST_PKG_IDENT gem env
+  [ $status -eq 0 ]
+}
+
+@test "includes bundler" {
+  run hab pkg exec $TEST_PKG_IDENT bundle -v
+  [ $status -eq 0 ]
+}
+
+@test "unresolvable DNS returns SocketError with glibc's standard nsswitch.conf" {
+  dns_error=$(hab pkg exec $TEST_PKG_IDENT ruby -r socket -e "
+    begin
+    Socket.pack_sockaddr_in(80, 'nope.example')
+    rescue Exception => e
+      p e.class.to_s
+    end
+  ")
+  diff <( echo "$dns_error") <( echo '"SocketError"' )
+}
+
+@test "unresolvable DNS returns SocketError with myhostname plugin enabled (for RHEL-flavored hosts)" {
+  # from RHEL's systemd-lib RPM spec %post action:
+  #sed-fu to add myhostname to the hosts line of /etc/nsswitch.conf
+  if [ -f /etc/nsswitch.conf ] ; then
+    sed -i.bak -e '
+    /^hosts:/ !b
+    /\<myhostname\>/ b
+    s/[[:blank:]]*$/ myhostname/
+    ' /etc/nsswitch.conf >/dev/null 2>&1 || :
+  fi
+  dns_error=$(hab pkg exec $TEST_PKG_IDENT ruby -r socket -e "
+    begin
+    Socket.pack_sockaddr_in(80, 'nope.example')
+    rescue Exception => e
+      p e.class.to_s
+    end
+  ")
+  mv /etc/nsswitch.conf.bak /etc/nsswitch.conf
+  diff <( echo "$dns_error") <( echo '"SocketError"' )
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${BASH_SOURCE[0]}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: ${0} FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
All binaries apart from rake and update_gems tested via inspec.  An issue #1 was raised as a result.  Also some BATS tests, which were added recently to verify that core/nss-myhostname fixes a dns issue, were not yet added to the inspec suite but may be added later.  See issue #2.

studio tests:

```rspec
Profile: Habitat Core Plan ruby (ruby)
Version: 0.1.0
Target:  local://

  ✔  core-plans-ruby-exists: Ensure ruby exists
     ✔  Command: `hab pkg path core/ruby` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/ruby` stdout is expected not to be empty
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/bundle is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/bundle is expected to be executable
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/erb is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/erb is expected to be executable
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/gem is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/gem is expected to be executable
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/irb is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/irb is expected to be executable
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/rake is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/rake is expected to be executable
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/rdoc is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/rdoc is expected to be executable
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/ri is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/ri is expected to be executable
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/ruby is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/ruby is expected to be executable
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/update_rubygems is expected to exist
     ✔  File /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/update_rubygems is expected to be executable
  ✔  core-plans-ruby-works: Ensure ruby works as expected
     ✔  Command: `hab pkg path core/ruby` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/ruby` stdout is expected not to be empty
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/bundle --help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/bundle --help 2>&1 stdout is expected to match /Bundler\s+commands:/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/erb --help 2>&1 exit_status is expected to cmp == /^[^0]/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/erb --help 2>&1 stdout is expected to match /erb\s+\[switches\]/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/gem env 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/gem env 2>&1 stdout is expected to match /RUBY\s+VERSION:\s+2.5.8/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/irb --help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/irb --help 2>&1 stdout is expected to match /usage:(\s+|.*)irb/i
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/rdoc --help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/rdoc --help 2>&1 stdout is expected to match /usage:(\s+|.*)rdoc/i
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/ri --help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/ri --help 2>&1 stdout is expected to match /usage:(\s+|.*)ri/i
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/ruby --version 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/core/ruby/2.5.8/20200928183217/bin/ruby --version 2>&1 stdout is expected to match /ruby\s+2.5.8/


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 36 successful, 0 failures, 0 skipped
```