### PR TITLE
Version bumped from 3.0.1 to 3.0.2

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=ruby
 pkg_origin=core
 pkg_major=3.0
-pkg_version=3.0.1
+pkg_version=3.0.2
 pkg_description="A dynamic, open source programming language with a focus on \
   simplicity and productivity. It has an elegant syntax that is natural to \
   read and easy to write."
@@ -9,7 +9,7 @@ pkg_license=("Ruby")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source=https://cache.ruby-lang.org/pub/${pkg_name}/${pkg_major}/${pkg_name}-${pkg_version}.tar.gz
 pkg_upstream_url=https://www.ruby-lang.org/en/
-pkg_shasum=369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727
+pkg_shasum=5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1
 pkg_deps=(core/glibc core/ncurses core/zlib core/openssl core/libyaml core/libffi core/readline core/nss-myhostname)
 pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/sed)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
As per below comment from Tim Smith to fix the CVEs
**"This should be 3.0.2 at this point, otherwise we have CVEs"**
https://github.com/chef-base-plans/ruby/pull/4#discussion_r710419878